### PR TITLE
changed module interfaces to access objectparent instead of data access

### DIFF
--- a/Runtime/ObjectHandling/DecodableDataExtensions.cs
+++ b/Runtime/ObjectHandling/DecodableDataExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright 2026 Spellbound Studio Inc.
 
+using Spellbound.Core.Logging;
+
 namespace Spellbound.Core {
     public static class DecodableDataExtensions {
         public static IDecodableData GetDefaultData<T>(
@@ -12,25 +14,26 @@ namespace Spellbound.Core {
         }
 
         public static void ChangeCallback<T>(
-            this T data, byte context, IObjectDataAccess dataAccess,
+            this T data, byte context, ObjectParent parent,
             int instanceIndex, ObjectPreset preset, int surfaceIndex, TransformData transformData)
                 where T : IDecodableData {
+
             if (!preset.TryGetModules<IChangeHandler<T>>(out var modules, surfaceIndex))
                 return;
 
             foreach (var module in modules)
-                module.OnChange(data, context, dataAccess, instanceIndex, preset, surfaceIndex, transformData);
+                module.OnChange(data, context, parent, instanceIndex, preset, surfaceIndex, transformData);
         }
 
         public static void ResolveCallback<T>(
-            this T data, byte context, IObjectDataAccess dataAccess,
+            this T data, byte context, ObjectParent parent,
             int instanceIndex, ObjectPreset preset, int surfaceIndex, TransformData transformData)
                 where T : IDecodableData {
             if (!preset.TryGetModules<IResolveHandler<T>>(out var modules, surfaceIndex))
                 return;
 
             foreach (var module in modules)
-                module.OnResolve(data, context, dataAccess, instanceIndex, preset, surfaceIndex, transformData);
+                module.OnResolve(data, context, parent, instanceIndex, preset, surfaceIndex, transformData);
         }
     }
 }

--- a/Runtime/ObjectHandling/IChangeHandler.cs
+++ b/Runtime/ObjectHandling/IChangeHandler.cs
@@ -9,7 +9,7 @@ namespace Spellbound.Core {
     /// <typeparam name="T"></typeparam>
     public interface IChangeHandler<T> where T : IDecodableData {
         void OnChange(
-            T data, byte context, IObjectDataAccess dataAccess, int instanceIndex, ObjectPreset preset,
+            T data, byte context, ObjectParent parent, int instanceIndex, ObjectPreset preset,
             int surfaceIndex, TransformData transformData);
     }
 }

--- a/Runtime/ObjectHandling/IDecodableData.cs
+++ b/Runtime/ObjectHandling/IDecodableData.cs
@@ -17,11 +17,11 @@ namespace Spellbound.Core {
         IDecodableData InvokeGetDefaultData(ObjectPreset preset, int surfaceIndex, byte level = 1);
 
         void InvokeChangeCallback(
-            byte context, IObjectDataAccess dataAccess, int instanceIndex,
+            byte context, ObjectParent parent, int instanceIndex,
             ObjectPreset preset, int surfaceIndex, TransformData transformData);
 
         void InvokeResolveCallback(
-            byte context, IObjectDataAccess dataAccess, int instanceIndex,
+            byte context, ObjectParent parent, int instanceIndex,
             ObjectPreset preset, int surfaceIndex, TransformData transformData);
 
         static IDecodableData Decode(string packerId, byte[] data) {

--- a/Runtime/ObjectHandling/IResolveHandler.cs
+++ b/Runtime/ObjectHandling/IResolveHandler.cs
@@ -9,7 +9,7 @@ namespace Spellbound.Core {
     /// <typeparam name="T"></typeparam>
     public interface IResolveHandler<T> where T : IDecodableData {
         void OnResolve(
-            T data, byte context, IObjectDataAccess dataAccess, int instanceIndex, ObjectPreset preset,
+            T data, byte context, ObjectParent parent, int instanceIndex, ObjectPreset preset,
             int surfaceIndex, TransformData transformData);
     }
 }

--- a/Runtime/ObjectHandling/ObjectParent.cs
+++ b/Runtime/ObjectHandling/ObjectParent.cs
@@ -490,22 +490,21 @@ namespace Spellbound.Core {
 
             surface.AlertChanged();
 
-            data.InvokeChangeCallback(context, StaticDataAccess, instanceIndex, preset, key.SurfaceIndex,
+            data.InvokeChangeCallback(context, this, instanceIndex, preset, key.SurfaceIndex,
                 transformData);
         }
 
         public void OnInstanceDataResolved(int instanceIndex, InstanceDataKey key, IDecodableData data, byte context) {
             if (!TryGetCallbackParamsFromEventSurface(instanceIndex, key.SurfaceIndex, out var transformData,
                     out var preset, out var surface))
-                return;
 
             if (!TryGetCallbackParamsFromEntity(instanceIndex, out transformData, out preset)) {
                 Log.Error("failed to find entity");
 
                 return;
             }
-
-            data.InvokeResolveCallback(context, StaticDataAccess, instanceIndex, preset, key.SurfaceIndex,
+            
+            data.InvokeResolveCallback(context, this, instanceIndex, preset, key.SurfaceIndex,
                 transformData);
         }
 


### PR DESCRIPTION
These changes were tweaks made while implementing the Smelter for Corsair's Isle. 

Changes to IDecodableData and Module Interfaces to go thru ObjectParent instead of accessing (static) IObjectDataAccess directly. This was REQUIRED for the static smelter to instantiate the dynamic copper ingot, but was also previously discussed as better architecture. 

Also fixed a bug in the OnInstanceDataRemoved method of ObjectParent where it was returning early.