### PR TITLE
Reusable Hashing and Registries

### DIFF
--- a/Runtime/Hashing.meta
+++ b/Runtime/Hashing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11c60234e3b3d2b42ad09b384649e924
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hashing/StableHash.cs
+++ b/Runtime/Hashing/StableHash.cs
@@ -7,22 +7,22 @@ namespace Spellbound.Core.Hashing {
     /// stable numeric id (registry keys, save / network ids) instead of re-implementing the algorithm inline.
     /// </summary>
     public static class StableHash {
-        public const uint Fnv1aOffset = 2166136261u;
-        public const uint Fnv1aPrime = 16777619u;
+        private const uint Fnv1AOffset = 2166136261u;
+        private const uint Fnv1APrime = 16777619u;
 
         /// <summary>
         /// Full 32-bit FNV-1a of <paramref name="value"/>. Empty or null returns 0, which callers treat as the
         /// reserved "null / none" id.
         /// </summary>
-        public static uint Fnv1a32(string value) {
+        public static uint Fnv1A32(string value) {
             if (string.IsNullOrEmpty(value))
                 return 0u;
 
-            var hash = Fnv1aOffset;
+            var hash = Fnv1AOffset;
 
-            for (var i = 0; i < value.Length; i++) {
-                hash ^= value[i];
-                hash *= Fnv1aPrime;
+            foreach (var t in value) {
+                hash ^= t;
+                hash *= Fnv1APrime;
             }
 
             return hash;
@@ -32,8 +32,8 @@ namespace Spellbound.Core.Hashing {
         /// 16-bit variant: the 32-bit hash folded down with XOR. Matches the value PackerRegistry computed
         /// inline before this util existed.
         /// </summary>
-        public static ushort Fnv1a16(string value) {
-            var hash = Fnv1a32(value);
+        public static ushort Fnv1A16(string value) {
+            var hash = Fnv1A32(value);
 
             return (ushort)(hash ^ (hash >> 16));
         }

--- a/Runtime/Hashing/StableHash.cs
+++ b/Runtime/Hashing/StableHash.cs
@@ -1,0 +1,41 @@
+// Copyright 2026 Spellbound Studio Inc.
+
+namespace Spellbound.Core.Hashing {
+    /// <summary>
+    /// Canonical hashing for stable, deterministic ids. FNV-1a (offset 2166136261, prime 16777619) over a
+    /// string produces the same value on every machine and build. Use this anywhere a string needs a compact,
+    /// stable numeric id (registry keys, save / network ids) instead of re-implementing the algorithm inline.
+    /// </summary>
+    public static class StableHash {
+        public const uint Fnv1aOffset = 2166136261u;
+        public const uint Fnv1aPrime = 16777619u;
+
+        /// <summary>
+        /// Full 32-bit FNV-1a of <paramref name="value"/>. Empty or null returns 0, which callers treat as the
+        /// reserved "null / none" id.
+        /// </summary>
+        public static uint Fnv1a32(string value) {
+            if (string.IsNullOrEmpty(value))
+                return 0u;
+
+            var hash = Fnv1aOffset;
+
+            for (var i = 0; i < value.Length; i++) {
+                hash ^= value[i];
+                hash *= Fnv1aPrime;
+            }
+
+            return hash;
+        }
+
+        /// <summary>
+        /// 16-bit variant: the 32-bit hash folded down with XOR. Matches the value PackerRegistry computed
+        /// inline before this util existed.
+        /// </summary>
+        public static ushort Fnv1a16(string value) {
+            var hash = Fnv1a32(value);
+
+            return (ushort)(hash ^ (hash >> 16));
+        }
+    }
+}

--- a/Runtime/Hashing/StableHash.cs.meta
+++ b/Runtime/Hashing/StableHash.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bda540e864e63e646b97cee2bcdbd967

--- a/Runtime/Registries.meta
+++ b/Runtime/Registries.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e10eb6ebc67aa2e4d811c5e354649df5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Registries/HashRegistry.cs
+++ b/Runtime/Registries/HashRegistry.cs
@@ -5,10 +5,7 @@ using Spellbound.Core.Logging;
 
 namespace Spellbound.Core.Registries {
     /// <summary>
-    /// Default in-memory <see cref="IRegistry{TEntry}"/> backend: a uint-hash to entry dictionary built from a
-    /// caller-supplied source (a manifest array, Resources.LoadAll, eventually database rows). Owns the
-    /// zero-hash and collision guards that every hand-rolled registry was duplicating. The uint key means no
-    /// boxing on lookup, and nothing here runs per frame.
+    /// Default in-memory <see cref="IRegistry{TEntry}"/> backend: a uint-hash to entry dictionary.
     /// </summary>
     public class HashRegistry<TEntry> : IRegistry<TEntry> where TEntry : class, IRegistryEntry {
         private readonly Dictionary<uint, TEntry> _byHash = new();
@@ -23,8 +20,7 @@ namespace Spellbound.Core.Registries {
         }
 
         /// <summary>
-        /// Registers one entry. Entries that are null, carry the reserved 0 hash, or collide with an
-        /// already-registered hash are rejected and logged; the first registration wins.
+        /// Registers one entry.
         /// </summary>
         public void Add(TEntry entry) {
             if (entry == null)
@@ -53,18 +49,18 @@ namespace Spellbound.Core.Registries {
             if (entries == null)
                 return;
 
-            for (var i = 0; i < entries.Count; i++)
-                Add(entries[i]);
+            foreach (var t in entries)
+                Add(t);
         }
 
         public bool TryGet(uint hash, out TEntry entry) {
-            if (hash == 0u) {
-                entry = null;
+            if (hash != 0u) 
+                return _byHash.TryGetValue(hash, out entry);
 
-                return false;
-            }
+            entry = null;
 
-            return _byHash.TryGetValue(hash, out entry);
+            return false;
+
         }
 
         public TEntry Get(uint hash) {

--- a/Runtime/Registries/HashRegistry.cs
+++ b/Runtime/Registries/HashRegistry.cs
@@ -1,0 +1,81 @@
+// Copyright 2026 Spellbound Studio Inc.
+
+using System.Collections.Generic;
+using Spellbound.Core.Logging;
+
+namespace Spellbound.Core.Registries {
+    /// <summary>
+    /// Default in-memory <see cref="IRegistry{TEntry}"/> backend: a uint-hash to entry dictionary built from a
+    /// caller-supplied source (a manifest array, Resources.LoadAll, eventually database rows). Owns the
+    /// zero-hash and collision guards that every hand-rolled registry was duplicating. The uint key means no
+    /// boxing on lookup, and nothing here runs per frame.
+    /// </summary>
+    public class HashRegistry<TEntry> : IRegistry<TEntry> where TEntry : class, IRegistryEntry {
+        private readonly Dictionary<uint, TEntry> _byHash = new();
+        private readonly List<TEntry> _all = new();
+
+        public int Count => _byHash.Count;
+        public IReadOnlyList<TEntry> All => _all;
+
+        public void Clear() {
+            _byHash.Clear();
+            _all.Clear();
+        }
+
+        /// <summary>
+        /// Registers one entry. Entries that are null, carry the reserved 0 hash, or collide with an
+        /// already-registered hash are rejected and logged; the first registration wins.
+        /// </summary>
+        public void Add(TEntry entry) {
+            if (entry == null)
+                return;
+
+            var hash = entry.Hash;
+
+            if (hash == 0u) {
+                Log.Error($"HashRegistry<{typeof(TEntry).Name}>: '{entry}' has hash 0 (reserved null). Skipped.");
+
+                return;
+            }
+
+            if (!_byHash.TryAdd(hash, entry)) {
+                Log.Error(
+                    $"HashRegistry<{typeof(TEntry).Name}>: hash collision {hash} " +
+                    $"('{_byHash[hash]}' vs '{entry}'). Kept first.");
+
+                return;
+            }
+
+            _all.Add(entry);
+        }
+
+        public void AddRange(IReadOnlyList<TEntry> entries) {
+            if (entries == null)
+                return;
+
+            for (var i = 0; i < entries.Count; i++)
+                Add(entries[i]);
+        }
+
+        public bool TryGet(uint hash, out TEntry entry) {
+            if (hash == 0u) {
+                entry = null;
+
+                return false;
+            }
+
+            return _byHash.TryGetValue(hash, out entry);
+        }
+
+        public TEntry Get(uint hash) {
+            if (hash != 0u && _byHash.TryGetValue(hash, out var entry))
+                return entry;
+
+            Log.Error($"HashRegistry<{typeof(TEntry).Name}>: no entry for hash {hash}.");
+
+            return null;
+        }
+
+        public bool Contains(uint hash) => hash != 0u && _byHash.ContainsKey(hash);
+    }
+}

--- a/Runtime/Registries/HashRegistry.cs.meta
+++ b/Runtime/Registries/HashRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a16386caf92566c46a6fb43a87e7e71b

--- a/Runtime/Registries/IRegistry.cs
+++ b/Runtime/Registries/IRegistry.cs
@@ -1,0 +1,18 @@
+// Copyright 2026 Spellbound Studio Inc.
+
+using System.Collections.Generic;
+
+namespace Spellbound.Core.Registries {
+    /// <summary>
+    /// A lookup of <typeparamref name="TEntry"/> by stable uint hash. This is the surface consumers depend on;
+    /// the backend behind it (the in-memory <see cref="HashRegistry{TEntry}"/>, or a future database) can be
+    /// swapped without touching callers.
+    /// </summary>
+    public interface IRegistry<TEntry> where TEntry : class {
+        bool TryGet(uint hash, out TEntry entry);
+        TEntry Get(uint hash);
+        bool Contains(uint hash);
+        int Count { get; }
+        IReadOnlyList<TEntry> All { get; }
+    }
+}

--- a/Runtime/Registries/IRegistry.cs
+++ b/Runtime/Registries/IRegistry.cs
@@ -4,9 +4,7 @@ using System.Collections.Generic;
 
 namespace Spellbound.Core.Registries {
     /// <summary>
-    /// A lookup of <typeparamref name="TEntry"/> by stable uint hash. This is the surface consumers depend on;
-    /// the backend behind it (the in-memory <see cref="HashRegistry{TEntry}"/>, or a future database) can be
-    /// swapped without touching callers.
+    /// A lookup of <typeparamref name="TEntry"/> by stable uint hash.
     /// </summary>
     public interface IRegistry<TEntry> where TEntry : class {
         bool TryGet(uint hash, out TEntry entry);

--- a/Runtime/Registries/IRegistry.cs.meta
+++ b/Runtime/Registries/IRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d3dcb87b7d0bbb469d17ca72ea81889

--- a/Runtime/Registries/IRegistryEntry.cs
+++ b/Runtime/Registries/IRegistryEntry.cs
@@ -1,0 +1,12 @@
+// Copyright 2026 Spellbound Studio Inc.
+
+namespace Spellbound.Core.Registries {
+    /// <summary>
+    /// Implemented by anything that can live in an <see cref="IRegistry{TEntry}"/>. Exposes a stable,
+    /// deterministic <see cref="Hash"/> that is identical on every machine and build. A hash of 0 is reserved
+    /// as the "null / none" id and is never stored in a registry.
+    /// </summary>
+    public interface IRegistryEntry {
+        uint Hash { get; }
+    }
+}

--- a/Runtime/Registries/IRegistryEntry.cs.meta
+++ b/Runtime/Registries/IRegistryEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 183cbb8074397504db7c43198010f479

--- a/Runtime/Registries/RegistryPacker.cs
+++ b/Runtime/Registries/RegistryPacker.cs
@@ -5,13 +5,12 @@ using Spellbound.Core.Packing;
 
 namespace Spellbound.Core.Registries {
     /// <summary>
-    /// Writes a registry entry as its 4-byte stable hash and resolves it back through a registry on read — the
-    /// "send one id, get the entry" round-trip for saves and network. A null entry or a 0 hash round-trips to
-    /// null.
+    /// Writes a registry entry as its 4-byte stable hash and resolves it back through a registry on read.
+    /// A null entry or a 0 hash round-trips to null.
     /// </summary>
     public static class RegistryPacker {
         public static void Write(ref Span<byte> buffer, IRegistryEntry entry) =>
-                Packer.WriteUInt(ref buffer, entry != null ? entry.Hash : 0u);
+                Packer.WriteUInt(ref buffer, entry?.Hash ?? 0u);
 
         public static TEntry Read<TEntry>(ref ReadOnlySpan<byte> buffer, IRegistry<TEntry> registry)
                 where TEntry : class {

--- a/Runtime/Registries/RegistryPacker.cs
+++ b/Runtime/Registries/RegistryPacker.cs
@@ -1,0 +1,28 @@
+// Copyright 2026 Spellbound Studio Inc.
+
+using System;
+using Spellbound.Core.Packing;
+
+namespace Spellbound.Core.Registries {
+    /// <summary>
+    /// Writes a registry entry as its 4-byte stable hash and resolves it back through a registry on read — the
+    /// "send one id, get the entry" round-trip for saves and network. A null entry or a 0 hash round-trips to
+    /// null.
+    /// </summary>
+    public static class RegistryPacker {
+        public static void Write(ref Span<byte> buffer, IRegistryEntry entry) =>
+                Packer.WriteUInt(ref buffer, entry != null ? entry.Hash : 0u);
+
+        public static TEntry Read<TEntry>(ref ReadOnlySpan<byte> buffer, IRegistry<TEntry> registry)
+                where TEntry : class {
+            var hash = Packer.ReadUInt(ref buffer);
+
+            if (hash == 0u || registry == null)
+                return null;
+
+            return registry.TryGet(hash, out var entry)
+                    ? entry
+                    : null;
+        }
+    }
+}

--- a/Runtime/Registries/RegistryPacker.cs.meta
+++ b/Runtime/Registries/RegistryPacker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 524a09dfe9d898f4f92b5d6d1727b1eb


### PR DESCRIPTION
Stable-Hash Registry: a Core abstraction

Context

A "lookup items by a stable id" pattern is used at least a dozen times across the game/libraries—
PackerRegistry, PresetResolver, ObjectPresetDatabase, EntityPrefabRegistry (Core);
TraitRegistry, StatRegistry, StatDefinitionRegistry (Modifiers); PlayerTemplateRegistry,
StatDatabase/PlayableRaceSO (Stats/_GameLogic); BiomeBlobDatabase (WorldSystem).

We need a shared hashing util and generic registry.